### PR TITLE
Add react-dom to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "raw-loader": "^0.5.1",
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.3.1",
+    "react-dom": "^15.2.1",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.3.0",


### PR DESCRIPTION
Dependency missing after a fresh `clone`.

```
react-addons-test-utils@15.4.2 requires a peer of react-dom@^15.4.2 but none was installed.
@kadira/storybook@2.35.3 requires a peer of react-dom@^0.14.7 || ^15.0.0 but none was installed.
redbox-react@1.3.4 requires a peer of react-dom@^0.14.0 || ^15.0.0 but none was installed.
@kadira/storybook-addon-links@1.0.1 requires a peer of react-dom@^0.14.7 || ^15.0.0 but none was installed.
react-modal@1.7.3 requires a peer of react-dom@^0.14.0 || ^15.0.0 but none was installed.
@kadira/storybook-addon-actions@1.1.3 requires a peer of react-dom@^0.14.7 || ^15.0.0 but none was installed.
@kadira/storybook-ui@3.11.0 requires a peer of react-dom@^0.14.7 || ^15.0.0 but none was installed.
@kadira/react-split-pane@1.4.7 requires a peer of react-dom@^0.14.8 || ^15.0.0 but none was installed.
```